### PR TITLE
v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # `stream-utils` Releases
 
+## v1.3.0 - October 29, 2018 [maven](http://repo2.maven.org/maven2/com/conductor/stream-utils/1.3.0/) 
+
+### Fix some issues in the code
+This release fixes some issues with stream utils.
+
+### Pull Requests Included
+- [Pull 14](https://github.com/Conductor/stream-utils/pull/14) - Make sure exceptions are thrown at the appropriate call. Closes [issue #10](https://github.com/Conductor/stream-utils/issues/10)
+- [Pull 15](https://github.com/Conductor/stream-utils/pull/15) - Make sure `switchIfEmpty` works when the alternate stream has a length of 1. Closes [issue #9](https://github.com/Conductor/stream-utils/issues/9)
+- [Pull 16](https://github.com/Conductor/stream-utils/pull/16) - Make sure all our methods that return different streams close the base stream appropriately. Closes [issue #8](https://github.com/Conductor/stream-utils/issues/8)
+
+### Compatibility
+This change is fully backwards compatible (unless you were relying on any of these bugs).
+
+
 ## v1.2.1 - May 31, 2018 [maven](http://repo2.maven.org/maven2/com/conductor/stream-utils/1.2.1/) 
 
 ### Update documentation

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>stream-utils</artifactId>
     <name>${project.artifactId}</name>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <description>A set of stream utilities for Java 8 Streams</description>
     <url>https://github.com/Conductor/stream-utils</url>

--- a/src/main/java/com/conductor/stream/utils/join/JoinBuilder.java
+++ b/src/main/java/com/conductor/stream/utils/join/JoinBuilder.java
@@ -45,9 +45,27 @@ public class JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> {
         return this;
     }
 
+    /**
+     * Getter so that we can appropriately clean up resources.
+     *
+     * @return the base stream on the left side
+     */
+    public Stream<LEFT_VALUE> getLeftHandSide() {
+        return leftHandSide;
+    }
+
     public JoinBuilder setRightHandSide(final Stream<RIGHT_VALUE> rightHandSide) {
         this.rightHandSide = rightHandSide;
         return this;
+    }
+
+    /**
+     * Getter so that we can appropriately clean up resources.
+     *
+     * @return the base stream on the right side
+     */
+    public Stream<RIGHT_VALUE> getRightHandSide() {
+        return rightHandSide;
     }
 
     public JoinBuilder setOrdering(final Comparator<KEY> ordering) {

--- a/src/main/java/com/conductor/stream/utils/misc/PeekingIterator.java
+++ b/src/main/java/com/conductor/stream/utils/misc/PeekingIterator.java
@@ -62,8 +62,9 @@ public class PeekingIterator<TYPE> implements Iterator<TYPE> {
             // Cycle the next item.
             this.nextObject = getNextObject();
         }
-        // as long as we currently hold on to an item, we coo'
-        return this.nextObject != null;
+        // as long as we currently hold on to an item, or
+        // we hold on to an exception, we coo'
+        return this.nextObject != null || this.caughtException != null;
     }
 
     /**

--- a/src/main/java/com/conductor/stream/utils/misc/SwitchIfEmptySpliterator.java
+++ b/src/main/java/com/conductor/stream/utils/misc/SwitchIfEmptySpliterator.java
@@ -63,6 +63,9 @@ public class SwitchIfEmptySpliterator<TYPE> implements Spliterator<TYPE> {
         if (!seen && !advanced) {
             // replace the stream with the replacement.
             streamSpliterator = alternateStreamSupplier.get().spliterator();
+            // since we now returned the secondary stream, set seen
+            // to true here as well
+            seen = true;
             // now we use the replacement stream's tryAdvance call
             return streamSpliterator.tryAdvance(action);
         }

--- a/src/test/java/com/conductor/stream/utils/StreamUtilsTest.java
+++ b/src/test/java/com/conductor/stream/utils/StreamUtilsTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
@@ -83,6 +84,12 @@ public class StreamUtilsTest {
     public void testSwitchIfEmpty() {
         final Stream<Integer> integerStream = StreamUtils.switchIfEmpty(Stream.empty(), () -> Stream.of(1, 2, 3));
         assertEquals(Arrays.asList(1, 2, 3), integerStream.collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testSwitchIfEmpty_endlessLoop() {
+        final Stream<Integer> integerStream = StreamUtils.switchIfEmpty(Stream.empty(), () -> Stream.of(1));
+        assertEquals(Collections.singletonList(1), integerStream.collect(Collectors.toList()));
     }
 
     @Test

--- a/src/test/java/com/conductor/stream/utils/misc/PeekingIteratorTest.java
+++ b/src/test/java/com/conductor/stream/utils/misc/PeekingIteratorTest.java
@@ -111,6 +111,33 @@ public class PeekingIteratorTest {
     }
 
     @Test
+    public void doesNotThrowExceptionUntilNextCall_whenHasNextReturnsTrueButNextThrows() {
+        // this test validates that if attempting to retrieve an item throws
+        // an exception, that exception is not thrown until the appropriate
+        // next/peek call happens.
+        // in this instance, the delegate is actually returning "true" when
+        // asked if it has next, and then calling next throws an exception.
+        // we want to preserve that behavior
+        when(mockIterator.hasNext()).thenReturn(true);
+        when(mockIterator.next()).thenThrow(new RuntimeException());
+        assertTrue(peekingIterator.hasNext());
+        boolean caught = false;
+        try {
+            peekingIterator.peek();
+        } catch(Exception e) {
+            caught = true;
+        }
+        assertTrue(caught);
+        caught = false;
+        try {
+            peekingIterator.next();
+        } catch(Exception e) {
+            caught = true;
+        }
+        assertTrue(caught);
+    }
+
+    @Test
     public void canCallPeekOrNextWithoutHasNextAsLongAsThereAreItemsLeft() {
         when(mockIterator.hasNext()).thenReturn(true);
         when(mockIterator.next()).thenReturn(1);


### PR DESCRIPTION

### Fix some issues in the code
This release fixes some issues with stream utils.
 ### Pull Requests Included
- [Pull 14](https://github.com/Conductor/stream-utils/pull/14) - Make sure exceptions are thrown at the appropriate call. Closes [issue #10](https://github.com/Conductor/stream-utils/issues/10)
- [Pull 15](https://github.com/Conductor/stream-utils/pull/15) - Make sure `switchIfEmpty` works when the alternate stream has a length of 1. Closes [issue #9](https://github.com/Conductor/stream-utils/issues/9)
- [Pull 16](https://github.com/Conductor/stream-utils/pull/16) - Make sure all our methods that return different streams close the base stream appropriately. Closes [issue #8](https://github.com/Conductor/stream-utils/issues/8)
 ### Compatibility
This change is fully backwards compatible (unless you were relying on any of these bugs).
