### PR TITLE
Fix type issues and add missing diamond operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # `stream-utils` Releases
 
+## v1.3.1 - November 2, 2018 [maven](http://repo2.maven.org/maven2/com/conductor/stream-utils/1.3.1/)
+This release fixes issues with types that would otherwise trigger unchecked assignment warnings
+
 ## v1.3.0 - October 29, 2018 [maven](http://repo2.maven.org/maven2/com/conductor/stream-utils/1.3.0/) 
 
 ### Fix some issues in the code

--- a/src/main/java/com/conductor/stream/utils/OrderedStreamUtils.java
+++ b/src/main/java/com/conductor/stream/utils/OrderedStreamUtils.java
@@ -16,12 +16,6 @@
 
 package com.conductor.stream.utils;
 
-import com.conductor.stream.utils.buffer.KeyedBufferIterator;
-import com.conductor.stream.utils.join.JoinBuilder;
-import com.conductor.stream.utils.join.JoinType;
-import com.conductor.stream.utils.join.JoiningIterator;
-import com.conductor.stream.utils.merge.SortedMergeIterator;
-
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -31,7 +25,10 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static com.conductor.stream.utils.join.JoinBuilder.builder;
+import com.conductor.stream.utils.buffer.KeyedBufferIterator;
+import com.conductor.stream.utils.join.JoinBuilder;
+import com.conductor.stream.utils.join.JoinType;
+import com.conductor.stream.utils.merge.SortedMergeIterator;
 
 /**
  * This class is a series of utilities specifically for dealing with
@@ -105,6 +102,7 @@ public final class OrderedStreamUtils {
      * @param streams the streams to merge together.
      * @return the stream of all the items, in order.
      */
+    @SuppressWarnings("unchecked")
     public static <TYPE extends Comparable> Stream<TYPE> sortedMerge(List<Stream<TYPE>> streams) {
         return sortedMerge(streams, Comparator.naturalOrder());
     }
@@ -127,7 +125,7 @@ public final class OrderedStreamUtils {
      * @return the stream of all the items, in order.
      */
     public static <TYPE> Stream<TYPE> sortedMerge(List<Stream<TYPE>> streams, Comparator<TYPE> comparator) {
-        final Iterator<TYPE> iter = new SortedMergeIterator(streams, comparator);
+        final Iterator<TYPE> iter = new SortedMergeIterator<>(streams, comparator);
 
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iter, 0), false)
                 // Whenever the merged stream is closed, we need to close the
@@ -168,7 +166,7 @@ public final class OrderedStreamUtils {
             final BiFunction<LEFT_VALUE, RIGHT_VALUE, RESULT> joinFunction,
             final JoinType joinType
     ) {
-        return join(builder()
+        return join(JoinBuilder.<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT>builder()
                 .setLeftHandSide(leftHandSide)
                 .setRightHandSide(rightHandSide)
                 .setOrdering(ordering)

--- a/src/main/java/com/conductor/stream/utils/join/JoinBuilder.java
+++ b/src/main/java/com/conductor/stream/utils/join/JoinBuilder.java
@@ -40,7 +40,7 @@ public class JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> {
 
     public JoinBuilder() {}
 
-    public JoinBuilder setLeftHandSide(final Stream<LEFT_VALUE> leftHandSide) {
+    public JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> setLeftHandSide(final Stream<LEFT_VALUE> leftHandSide) {
         this.leftHandSide = leftHandSide;
         return this;
     }
@@ -54,7 +54,7 @@ public class JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> {
         return leftHandSide;
     }
 
-    public JoinBuilder setRightHandSide(final Stream<RIGHT_VALUE> rightHandSide) {
+    public JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> setRightHandSide(final Stream<RIGHT_VALUE> rightHandSide) {
         this.rightHandSide = rightHandSide;
         return this;
     }
@@ -68,27 +68,27 @@ public class JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> {
         return rightHandSide;
     }
 
-    public JoinBuilder setOrdering(final Comparator<KEY> ordering) {
+    public JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> setOrdering(final Comparator<KEY> ordering) {
         this.ordering = ordering;
         return this;
     }
 
-    public JoinBuilder setLeftHandKeyingFunction(final Function<LEFT_VALUE, KEY> leftHandKeyingFunction) {
+    public JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> setLeftHandKeyingFunction(final Function<LEFT_VALUE, KEY> leftHandKeyingFunction) {
         this.leftHandKeyingFunction = leftHandKeyingFunction;
         return this;
     }
 
-    public JoinBuilder setRightHandKeyingFunction(final Function<RIGHT_VALUE, KEY> rightHandKeyingFunction) {
+    public JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> setRightHandKeyingFunction(final Function<RIGHT_VALUE, KEY> rightHandKeyingFunction) {
         this.rightHandKeyingFunction = rightHandKeyingFunction;
         return this;
     }
 
-    public JoinBuilder setJoinFunction(final BiFunction<LEFT_VALUE, RIGHT_VALUE, RESULT> joinFunction) {
+    public JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> setJoinFunction(final BiFunction<LEFT_VALUE, RIGHT_VALUE, RESULT> joinFunction) {
         this.joinFunction = joinFunction;
         return this;
     }
 
-    public JoinBuilder setJoinType(final JoinType joinType) {
+    public JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> setJoinType(final JoinType joinType) {
         this.joinType = joinType;
         return this;
     }
@@ -102,7 +102,7 @@ public class JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> {
         Objects.requireNonNull(joinFunction, "Join function must not be null.");
         Objects.requireNonNull(joinType, "Join type must not be null.");
 
-        return new JoiningIterator(
+        return new JoiningIterator<>(
                 leftHandSide,
                 rightHandSide,
                 ordering,
@@ -118,7 +118,7 @@ public class JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> {
      *
      * @return a builder.
      */
-    public static JoinBuilder builder() {
-        return new JoinBuilder();
+    public static <KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> JoinBuilder<KEY, LEFT_VALUE, RIGHT_VALUE, RESULT> builder() {
+        return new JoinBuilder<>();
     }
 }


### PR DESCRIPTION
This fixes some issues that were triggering unchecked assignment warnings because the type information was missing in the builders, also found some cases of missing diamond operator that also triggered unchecked assignment warnings.

@benmanbs 